### PR TITLE
Enforce node 0.11.10 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mpromise": "0.5.5",
     "underscore": "1.5.2"
   },
+  "engines": { "node": "0.11.10" },
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
@alabid see https://www.npmjs.org/doc/files/package.json.html#engines . Just so we have multiple layers of redundancy because this won't work on any other version of node thus far
