### PR TITLE
iteration 1 for enabling compat with jstests/core:array*.js, array_*.js,...

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,0 +1,94 @@
+var assert = require("assert");
+var util = require("util");
+var helpers = require("./nimrodhelpers");
+
+var additionalMethods = {
+  docEq: assert.deepEqual,
+  eq: assert.deepEqual,
+  neq: assert.notEqual,
+  commandWorked: function(res, msg) {
+    assert.ok(res.ok == 1, msg);
+  },
+  commandFailed: function(res, msg) {
+    assert.ok(res.ok == 0, msg);
+  },
+
+  throws: function(func, params, msg) {
+    try {
+      func.apply(null, params);
+    }
+    catch (e) {
+      return e;
+    }
+    assert.ok(0, util.format("did not throw exception: %s", msg));
+  },
+  between: function(a, b, c, msg, inclusive) {
+    var mes = util.format("%s is not between %s and %s: %s", b, a, c, msg);
+    if (inclusive == true || inclusive == undefined) {
+      assert.ok(a <= b && b <= c, mes);
+    } else {
+      assert.ok(a < b && b < c, mes);
+    }
+  },
+  betweenIn: function(a, b, c, msg) {
+    this.between(a, b, c, msg, true);
+  },
+  betweenEx: function(a, b, c, msg) {
+    this.between(a, b, c, msg, false);
+  },
+  lte: function(a, b, msg) {
+    assert.ok(a <= b, util.format("%s is not less than or equal to %s: %s",
+                                  a, b, msg));
+  },
+  lt: function(a, b, msg) {
+    assert.ok(a < b, util.format("%s is not less than %s: %s",
+                                  a, b, msg));
+  },
+  gte: function(a, b, msg) {
+    assert.ok(a >= b, util.format("%s is not greater than or equal to %s: %s",
+                                  a, b, msg));
+  },
+  gt: function(a, b, msg) {
+    assert.ok(a > b, util.format("%s is not greater than %s: %s",
+                                 a, b, msg));
+  },
+  close: function(a, b, msg, places) {
+    if (places === undefined) {
+      places = 4;
+    }
+    assert.ok(Math.round((a-b) * Math.pow(10, places)) == 0,
+              util.format("%s is not equal to %s within %s places, diff: %s : %s",
+                          a, b, places, (a-b), msg));
+  }
+};
+
+module.exports = function (val) {
+  if (val) {
+    assert.ok(val);
+    return;
+  }
+};
+
+module.exports.__proto__ = Proxy.create({
+  getOwnPropertyNames: function() {
+    return Object.getOwnPropertyNames(assert).concat(
+      Object.keys(additionalMethods)
+    );
+  },
+  getOwnPropertyDescriptor: function(proxy, key) {
+    return {"writable": false,
+            "enumerable": false,
+            "configurable" : true
+           };
+  },
+  getPropertyDescriptor: function(proxy, key) {
+    return this.getOwnPropertyDescriptor(proxy, key);
+  },
+  get: function(proxy, key) {
+    delete assert.throws;
+    if (assert.hasOwnProperty(key)) {
+      return assert[key];
+    }
+    return additionalMethods[key];
+  }
+});

--- a/lib/bsontypes.js
+++ b/lib/bsontypes.js
@@ -1,0 +1,38 @@
+var mongodb = require("mongodb");
+var util = require("util");
+function ObjectId(id) {
+  if(!(this instanceof ObjectId)) {
+    return new ObjectId(id);
+  }
+  if (id) {
+    this.oid = mongodb.ObjectID.createFromHexString(id);
+  } else {
+    this.oid = new mongodb.ObjectID();
+  }
+  var _this = this;
+  Object.defineProperty(this, "str", {
+    enumerable: true,
+    value: _this.oid.toHexString()
+  });
+}
+
+Object.prototype.getTimestamp = function() {
+  return this.oid.getTimestamp();
+};
+
+ObjectId.prototype.toString = function() {
+  return util.format("ObjectId(\"%s\")", this.str);
+};
+
+ObjectId.prototype.equals = function(otherId) {
+  return this.oid.equals(otherId.oid);
+}
+
+module.exports = {
+  ObjectId: ObjectId,
+  DBRef: mongodb.DBRef,
+  MinKey: mongodb.MinKey,
+  MaxKey: mongodb.MaxKey,
+  Symbol: mongodb.Symbol,
+  Timestamp: mongodb.Timestamp
+};

--- a/lib/collectionmethods.js
+++ b/lib/collectionmethods.js
@@ -1,19 +1,79 @@
 var _ = require("underscore");
 var helpers = require("./nimrodhelpers");
 var util = require("util");
-var Cursor = require('mongodb').Cursor;
+var Cursor = require("mongodb").Cursor;
+var ObjectID = require("mongodb").ObjectID;
 
-function ShellIterator(conn) {
-  var cursor = conn.flow.wait();
+function makeCommandObj(obj, collName) {
+  if (typeof obj === "string") {
+    var cmd = {};
+    cmd[obj] = collName;
+    obj = cmd;
+  }
+  return obj;
+}
+
+
+function BulkWriteResultWrapper(base) {
+  this.__proto__ = base;
+
+  var _this = this;
+  this.toSingleResult = function() {
+    var single = {"nMatched": base.nMatched,
+                  "nUpserted": base.nUpserted,
+                  "nModified": base.nModified,
+                  "_id": base.getUpsertedIdAt(0)._id};
+    var singleResult = helpers.extend(single, _this);
+    singleResult.getUpsertedId = function() {
+      return _this.getUpsertedIdAt(0);
+    };
+    return singleResult;
+  };
+};
+
+function BulkOp(conn, base) {
+  this.__proto__ = base;
+
+  this.execute = function(options) {
+    if (!options) {
+      options = {};
+    }
+    base.execute(options, conn.flow.addNoError());
+    return new BulkWriteResultWrapper(conn.flow.waitProper());
+  };
+}
+
+
+function ShellIterator(conn, coll) {
+  var cursor = conn.flow.waitProper();
   var _this = this;
 
   var nextDoc;
   var hasNextCalled = false;
 
+  this.countReturn = function(){
+    var c = this.count();
+
+    if (cursor.skipValue) {
+      c = c - cursor.skipValue;
+    }
+    if (cursor.limitValue > 0 && cursor.limitValue < c) {
+        return cursor.limitValue;
+    }
+
+    return Math.max(0, c);
+  };
+
+  this.size = this.countReturn;
+
+  this.arrayAccess = function (idx){
+    return this.toArray()[idx];
+  };
+
   this.hasNext = function() {
     if (!hasNextCalled) {
       cursor.nextObject(conn.flow.addNoError());
-      nextDoc = conn.flow.wait();
+      nextDoc = conn.flow.waitProper();
     }
     hasNextCalled = true;
     return !!nextDoc;
@@ -40,20 +100,31 @@ function ShellIterator(conn) {
   this.length = this.itcount;
 
   this.hint = function(obj) {
+    if (typeof obj === "object") {
+      var index = coll.getIndexes().filter(function(index) {
+        return _.isEqual(index.key, obj);
+      });
+      if (index.length) {
+        obj = index[0].name;
+      } else {
+        throw new Error("bad hint index name or key");
+      }
+    }
     cursor =  new Cursor(cursor.db, cursor.collection,
                          cursor.selector, cursor.fields,
-                         {hint: obj});
+                         {"hint":obj});
     return _this;
   };
 
   _.each(["count", "explain"], function(fn) {
     _this[fn] = function() {
-      cursor[fn].call(cursor, conn.flow.addNoError());
-      return conn.flow.wait();
+      var args = Array.prototype.slice.call(arguments, 0).concat(conn.flow.addNoError());
+      cursor[fn].apply(cursor, args);
+      return conn.flow.waitProper();
     };
   });
 
-  _.each(["sort", "limit", "skip"], function(fn) {
+  _.each(["sort", "limit", "skip", "batchSize"], function(fn) {
     _this[fn] = function() {
       cursor[fn].apply(cursor, arguments);
       return _this;
@@ -112,49 +183,91 @@ function indexSpec(fullCollName, keys, options) {
   else {
     throw new Error(util.format("can't handle: %j", typeof options));
   }
+  return ret;
 };
 
-var methods = function(conn) {
+var methods = function(dbLit, conn) {
   return function(collectionName) {
     return {
+      initializeOrderedBulkOp: function(options) {
+        if (!options) {
+          options = {};
+        }
+        var bulk = conn.db.collection(collectionName).initializeOrderedBulkOp(options);
+        return new BulkOp(conn, bulk);
+      },
+      initializeUnorderedBulkOp: function(options) {
+        if (!options) {
+          options = {};
+        }
+        var bulk = conn.db.collection(collectionName).initializeUnorderedBulkOp(options);
+        return new BulkOp(conn, bulk);
+      },
+      getMongo: function() {
+        return this.getDB().getMongo();
+      },
+      runCommand: function(cmd, params) {
+        cmd = makeCommandObj(cmd, collectionName);
+        var db = this.getDB();
+        if (typeof cmd === "object") {
+          return db.runCommand(cmd);
+        }
+        var c = {};
+        c[cmd] = this.getName();
+        if (params) {
+          helpers.extend(c, params);
+        }
+        return db.runCommand(c);
+      },
+      getName: function() {
+        return collectionName;
+      },
+      getDB: function() {
+        return Proxy.create(dbLit(conn));
+      },
       find: function(q, fields, limit, skip, batchSize, options) {
         options = limit ? (options.limit = limit, options) : options;
         options = skip ? (options.skip = skip, options) : options;
         options = batchSize ? (options.batchSize = batchSize, options) : options;
 
         conn.db.collection(collectionName).find(q, fields, options, conn.flow.addNoError());
-        return new ShellIterator(conn);
+        return new ShellIterator(conn, this);
       },
       findOne: function(q, fields, options) {
         conn.db.collection(collectionName).findOne(q, fields, options, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
       insert: function(doc, options) {
         if (!options) {
           options = {};
         }
         conn.db.collection(collectionName).insert(doc, options, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
       count: function(q) {
         conn.db.collection(collectionName).count(q, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
       remove: function(q, justOne) {
         var options = justOne ? {"single": justOne} : {};
+        q = q instanceof ObjectID ? {"_id" : q } : q;
         conn.db.collection(collectionName).remove(q, options, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
       update: function(q, obj, upsert, multi) {
         var options = (upsert || multi) ?
           {"upsert": upsert, "multi": multi} : {};
         conn.db.collection(collectionName).update(q, obj, options, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
 
       // =================  others  =================
       getFullName: function() {
         return util.format("%s.%s", conn.db.databaseName, collectionName);
+      },
+
+      toString: function() {
+        return this.getFullName();
       },
 
       clean: function() {
@@ -180,23 +293,17 @@ var methods = function(conn) {
         conn.db.collection(collectionName).aggregate(
           pipeline, opts, conn.flow.addNoError()
         );
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
 
       ensureIndex: function(fieldOrSpec, options) {
-        if (!options) {
-          options = {};
-        }
-        conn.db.collection(collectionName).ensureIndex(
-          fieldOrSpec, options, conn.flow.addNoError()
-        );
-        return conn.flow.wait();
+        return this.createIndex(fieldOrSpec, options);
       },
 
       copyTo: function(newName) {
         var to = conn.db.collection(newName);
         to.ensureIndex({ _id: 1}, conn.flow.addNoError());
-        conn.flow.wait();
+        conn.flow.waitProper();
 
         var count = 0;
         var cursor = this.find();
@@ -204,7 +311,7 @@ var methods = function(conn) {
           var o = cursor.next();
           count++;
           to.update({_id:o._id}, o, { upsert: true } , conn.flow.addNoError());
-          conn.flow.wait();
+          conn.flow.waitProper();
         }
 
         return count;
@@ -301,12 +408,20 @@ var methods = function(conn) {
         }
       },
 
+      getIndexKeys: function (){
+        return this.getIndexes().map(
+          function(i){
+            return i.key;
+          }
+        );
+      },
+
       getIndexes: function() {
         var dbName = conn.db.databaseName;
         conn.db.collection("system.indexes").find({
           ns: util.format("%s.%s", dbName, collectionName)
         }, conn.flow.addNoError());
-        return new ShellIterator(conn).toArray();
+        return new ShellIterator(conn, this).toArray();
       },
 
       indexStats: function(params) {
@@ -327,33 +442,33 @@ var methods = function(conn) {
 
       isCapped: function() {
         conn.db.collection(collectionName).options(conn.flow.addNoError());
-        var options = conn.flow.wait();
+        var options = conn.flow.waitProper();
         return !!(options && options.capped);
       },
 
       mapReduce: function(map, reduce, options) {
         conn.db.collection(collectionName).mapReduce(map, reduce, options, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
 
       reIndex: function() {
         conn.db.collection(collectionName).reIndex(conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
 
       renameCollection: function(newName, options) {
         conn.db.collection(collectionName).rename(newName, options, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
 
       save: function(obj, opts) {
         conn.db.collection(collectionName).save(obj, opts, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
 
       stats: function(opts) {
         conn.db.collection(collectionName).stats(opts, conn.flow.addNoError());
-        return conn.flow.wait();
+        return conn.flow.waitProper();
       },
 
       storageSize: function() {
@@ -380,4 +495,5 @@ var methods = function(conn) {
 
 exports.ShellIterator = ShellIterator;
 exports.Instance = methods;
+exports.BulkWriteResult = BulkWriteResultWrapper;
 

--- a/lib/dbmethods.js
+++ b/lib/dbmethods.js
@@ -4,6 +4,17 @@ var ShellIterator = require("./collectionmethods").ShellIterator;
 var MongoShellObj = require("./mongoshellobj");
 var crypto = require("crypto");
 
+
+function makeCommandObj(obj) {
+  if (typeof obj === "string") {
+    var cmd = {};
+    cmd[obj] = 1;
+    obj = cmd;
+  }
+  return obj;
+}
+
+
 function hex_md5(input) {
   return crypto.createHash("md5").update(input).digest("hex");
 }
@@ -24,6 +35,31 @@ module.exports = function(dbLit, conn) {
   var _defaultWriteConcern = { "w": "majority", "wtimeout": 30 * 1000 };
 
   return {
+
+    stats: function(scale) {
+      return this.runCommand({ "dbstats" : 1, "scale" : scale });
+    },
+
+    createCollection: function(collName, options) {
+      conn.db.createCollection(collName, options, conn.flow.addNoError());
+      return conn.flow.waitProper();
+    },
+
+    hostInfo: function() {
+      return this.adminCommand("hostInfo");
+    },
+
+    currentOp: function(arg) {
+      var q = {};
+      if (arg) {
+        if (typeof arg === "object") {
+          helpers.extend(q, arg);
+        } else if (arg) {
+          q["$all"] = true;
+        }
+      }
+      return this.getCollection("$cmd.sys.inprog").findOne(q);
+    },
 
     dropDatabase: function() {
       if (arguments.length) {
@@ -54,11 +90,17 @@ module.exports = function(dbLit, conn) {
     },
 
     adminCommand: function(cmd) {
+      cmd = makeCommandObj(cmd);
       return helpers.cleanupDocs(helpers.runAdminCommand(conn, cmd));
     },
 
     runCommand: function(cmd) {
-      return helpers.cleanupDocs(helpers.runCommand(conn, cmd));
+      cmd = makeCommandObj(cmd);
+      var res = helpers.cleanupDocs(helpers.runCommand(conn, cmd));
+      if (res instanceof Error) {
+        delete res.originalError;
+      }
+      return res;
     },
 
     getSiblingDB: function(dbName) {
@@ -150,7 +192,7 @@ module.exports = function(dbLit, conn) {
         throw new Error("auth expects either (username, password) or ({ user: username, pwd: password })");
       }
 
-      var res = conn.flow.wait();
+      var res = conn.flow.waitProper();
       if (res instanceof Error && res.name == 'MongoError') {
         return 0;
       }
@@ -163,7 +205,7 @@ module.exports = function(dbLit, conn) {
       } else {
         conn.db.logout(conn.flow.addNoError());
       }
-      if (conn.flow.wait()) {
+      if (conn.flow.waitProper()) {
         return {"ok": 1};
       }
       return {"ok": 0};
@@ -175,7 +217,7 @@ module.exports = function(dbLit, conn) {
       } else {
         conn.db.removeUser(user, conn.flow.addNoError());
       }
-      return conn.flow.wait();
+      return conn.flow.waitProper();
     },
 
     changeUserPassword: function(user, pass, wc) {
@@ -217,7 +259,6 @@ module.exports = function(dbLit, conn) {
       var cmdObj = {"dropUser": user,
                     "writeConcern": wc ? wc : _defaultWriteConcern};
       var res = this.runCommand(cmdObj);
-
       if (res.ok) {
         return true;
       }

--- a/lib/extcommands.js
+++ b/lib/extcommands.js
@@ -45,7 +45,7 @@ module.exports = function(conn) {
       case 'databases':
       case 'dbs':
         conn.db.admin().command({'listDatabases':1}, conn.flow.addNoError());
-        var dbs = helpers.cleanupDocs(conn.flow.wait());
+        var dbs = helpers.cleanupDocs(conn.flow.waitProper());
         var dbInfo = [];
         var maxNameLength = 0;
         var maxGbDigits = 0;
@@ -92,7 +92,7 @@ module.exports = function(conn) {
       case 'tables':
       case 'collections':
         conn.db.collectionNames(conn.flow.addNoError());
-        conn.flow.wait().forEach(function(obj) {
+        conn.flow.waitProper().forEach(function(obj) {
           var collName = obj.name;
           console.log(collName.substr(collName.indexOf(".")+1));
         });

--- a/lib/mongoshellobj.js
+++ b/lib/mongoshellobj.js
@@ -1,0 +1,36 @@
+var helpers = require("./nimrodhelpers");
+
+module.exports = function(db, conn) {
+
+  return {
+    host: conn.db.serverConfig.host,
+    port: conn.db.serverConfig.port,
+
+    adminCommand: db.adminCommand,
+    getCollection: db.getCollection,
+    getDB: function(name) {
+      return db.getSiblingDB(name);
+    },
+    getDBs: function() {
+      var res = helpers.runCommand({"listDatabases" : 1});
+      if (!res.ok) {
+        throw new Error("listDatabases failed: %s", res);
+      }
+      return res;
+    },
+    getDBNames: function() {
+      return this.getDBs().databases.map(function(z) {
+        return z.name;
+      });
+    },
+    setLogLevel: function(logLevel) {
+      return db.adminCommand({ "setParameter": 1, "logLevel": logLevel });
+    },
+    useWriteCommands: function() {
+      return true;
+    },
+    writeMode: function() {
+      return "commands";
+    }
+  };
+};

--- a/lib/nimrodhelpers.js
+++ b/lib/nimrodhelpers.js
@@ -9,7 +9,13 @@ var jsTest = {
   ],
   "adminUserRoles" : [
     "root"
-  ]
+  ],
+  "options" : function() {
+    return { "enableTestCommands" : true };
+  },
+  "log" : function (msg){
+    console.log( "\n\n----\n" + msg + "\n----\n\n" )
+  }
 };
 
 var AggregationCursor = function(conn, cursor) {
@@ -19,12 +25,12 @@ var AggregationCursor = function(conn, cursor) {
   this.close = function() {
     cursor.close(conn.flow.addNoError());
     closed = true;
-    return conn.flow.wait();
+    return conn.flow.waitProper();
   };
 
   this.explain = function() {
     cursor.explain(conn.flow.addNoError());
-    return conn.flow.wait();
+    return conn.flow.waitProper();
   };
 
   this.toArray = function() {
@@ -40,7 +46,7 @@ var AggregationCursor = function(conn, cursor) {
   this.hasNext = function() {
     if (!hasNextCalled) {
       cursor.next(conn.flow.addNoError());
-      nextDoc = conn.flow.wait();
+      nextDoc = conn.flow.waitProper();
     }
     hasNextCalled = true;
     return (closed ? false : nextDoc !== null);
@@ -116,7 +122,27 @@ Object.keySet = function(o) {
   return ret;
 }
 
+
+
 module.exports = {
+  doassert: function (msg) {
+    // eval if msg is a function
+    if (typeof msg === "function") {
+      msg = msg();
+    }
+    if (typeof (msg) === "string" && msg.indexOf("assert") === 0) {
+      console.log(msg);
+    } else {
+      console.log("assert: " + msg);
+    }
+
+    var ex = new Error(msg);
+    console.log(ex.stack);
+    throw ex;
+  },
+
+  printjson: function(x) { console.log(this.tojson(x)); },
+
   tojson: function(jsObj) { return JSON.stringify(jsObj, null, 4); },
 
   jsTest: jsTest,
@@ -159,18 +185,18 @@ module.exports = {
 
   collectionExists: function(conn, collName) {
     conn.db.collectionNames(collName, conn.flow.addNoError());
-    var result = conn.flow.wait();
+    var result = conn.flow.waitProper();
     return result.length > 0;
   },
 
   runCommand: function(conn, obj) {
     conn.db.command(obj, conn.flow.addNoError());
-    return conn.flow.wait();
+    return conn.flow.waitProper();
   },
 
   runAdminCommand: function(conn, obj) {
     conn.db.admin().command(obj, conn.flow.addNoError());
-    return conn.flow.wait();
+    return conn.flow.waitProper();
   },
 
   cleanupDocs: function(res) {
@@ -185,6 +211,18 @@ module.exports = {
       res = res[0];
     }
     return res;
+  },
+
+  wrapFlow: function(flow) {
+    flow.addNoError = function() { return this.add({ignoreError: true}); };
+    flow.waitProper = function() {
+      var res = this.wait();
+      if (res instanceof Error) {
+        throw res;
+      }
+      return res;
+    };
+    return flow;
   }
 };
 

--- a/lib/random.js
+++ b/lib/random.js
@@ -1,0 +1,4 @@
+module.exports = {
+  rand: function() { return Math.random(); },
+  srand: function(seed) { /* We can't seed RNG's in Javascript, unfortunately */ }
+};

--- a/lib/rshelpers.js
+++ b/lib/rshelpers.js
@@ -11,7 +11,7 @@ function RSHelpers(conn) {
 
   this.conf = function () {
     conn.db.db("local").collection("system.replset").findOne({}, conn.flow.addNoError());
-    return helpers.cleanupDocs(conn.flow.wait());
+    return helpers.cleanupDocs(conn.flow.waitProper());
   };
 
   this.reconfig = function(cfg, options) {


### PR DESCRIPTION
# Iteration 1

Added the following:
1) NodeJS' built in assert module, with assert.eq as a shorthand for assert.equal. Might need to make it a shorthand for assert.deepEqual, not sure if assert.eq is a deep equality check or not.

2) Array.sum, Array.avg, Array.stdDev: https://github.com/mongodb/mongo/blob/master/jstests/core/array3.js

3) print() as a wrapper around console.log()

4) ShellIterator.itcount() https://github.com/mongodb/mongo/blob/master/jstests/core/array_match1.js

5) getSisterDB() as an alias for getSiblingDB() https://github.com/mongodb/mongo/blob/master/jstests/core/auth_copydb.js

Plus, added 'explain', 'hint' to cursor.
